### PR TITLE
Use partCounter in question parts

### DIFF
--- a/homework.cls
+++ b/homework.cls
@@ -109,14 +109,14 @@
 % ----- Question Parts --------------------------------------------------------
 
 \newenvironment{alphaparts}[0]{%
-  \begin{enumerate}[label=\textbf{(\alph*)}]%
+  \begin{enumerate}[label=\textbf{(\alph{partCounter})}]%
 }{\end{enumerate}}
 
 \newenvironment{arabicparts}[0]{%
-  \begin{enumerate}[label=\textbf{\arabic{questionCounter}.\arabic*})]%
+  \begin{enumerate}[label=\textbf{\arabic{questionCounter}.\arabic{partCounter}})]%
 }{\end{enumerate}}
 
-\newcommand{\questionpart}[0]{\item}
+\newcommand{\questionpart}[0]{\stepcounter{partCounter}\item}
 
 % ----- Induction Environment -------------------------------------------------
 


### PR DESCRIPTION
This change uses the "partCounter" when working with either \alphaparts or \arabicparts question parts. This allows for splitting the list of question parts with some additional question text in between (i.e. using more than one \alphaparts or \arabicparts environment within a question) while still getting a continued enumeration label within the same question.